### PR TITLE
fix: Add 'extern PGDLLEXPORT' keywords to load in pg16.

### DIFF
--- a/src/fio.h
+++ b/src/fio.h
@@ -54,13 +54,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-Datum fio_writefile(PG_FUNCTION_ARGS);
-Datum fio_readfile(PG_FUNCTION_ARGS);
-Datum fio_readdir(PG_FUNCTION_ARGS);
-Datum fio_mkdir(PG_FUNCTION_ARGS);
-Datum fio_chmod(PG_FUNCTION_ARGS);
-Datum fio_removefile(PG_FUNCTION_ARGS);
-Datum fio_renamefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_writefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_readfile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_readdir(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_mkdir(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_chmod(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_removefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_renamefile(PG_FUNCTION_ARGS);
 #endif
 
 #ifndef FALSE


### PR DESCRIPTION
Add 'extern PGDLLEXPORT' keywords to load in pg16.